### PR TITLE
feat: add offline asset support

### DIFF
--- a/integration/app-with-serverless-offline/package.json
+++ b/integration/app-with-serverless-offline/package.json
@@ -6,7 +6,9 @@
   "scripts": {},
   "author": "Daniel Conde <danielconde9@gmail.com>",
   "license": "MIT",
-  "devDependencies": {},
+  "devDependencies": {
+    "serverless-nextjs-plugin": "file:../../packages/serverless-nextjs-plugin"
+  },
   "dependencies": {
     "next-aws-lambda": "file:../../packages/next-aws-lambda"
   }

--- a/integration/app-with-serverless-offline/pages/image.js
+++ b/integration/app-with-serverless-offline/pages/image.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+function Static() {
+    return <img style={{background: 'black'}} src="/static/checkmark.svg" />
+};
+
+export default Static;

--- a/integration/app-with-serverless-offline/static/checkmark.svg
+++ b/integration/app-with-serverless-offline/static/checkmark.svg
@@ -1,11 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#FFFFFF;}
-</style>
-<g id="Production_1_">
-	<polygon class="st0" points="49.8,11.1 25.6,43.6 11.1,27 8.9,29 25.8,48.4 52.2,12.9 	"/>
-</g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60"><path fill="#fff" d="M49.8 11.1L25.6 43.6 11.1 27l-2.2 2 16.9 19.4 26.4-35.5z"/></svg>

--- a/integration/app-with-serverless-offline/static/checkmark.svg
+++ b/integration/app-with-serverless-offline/static/checkmark.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g id="Production_1_">
+	<polygon class="st0" points="49.8,11.1 25.6,43.6 11.1,27 8.9,29 25.8,48.4 52.2,12.9 	"/>
+</g>
+</svg>

--- a/packages/serverless-nextjs-plugin/__tests__/index.test.js
+++ b/packages/serverless-nextjs-plugin/__tests__/index.test.js
@@ -33,6 +33,16 @@ describe("ServerlessNextJsPlugin", () => {
     });
   });
 
+  describe("#offlineIntegration", () => {
+    it("should special case offline plugin", () => {
+      const plugin = new ServerlessPluginBuilder()
+        .withService({ plugins: ["serverless-offline"] })
+        .build();
+
+      expect(plugin["offline"]).toEqual({ enabled: true });
+    });
+  });
+
   describe("#printStackOutput", () => {
     it("should call displayStackOutput with awsInfo", () => {
       const awsInfo = {

--- a/packages/serverless-nextjs-plugin/classes/NextPage.js
+++ b/packages/serverless-nextjs-plugin/classes/NextPage.js
@@ -67,6 +67,13 @@ class NextPage {
         return "/";
       case "_error":
         return "/{proxy+}";
+      // Special helpers for serverless-offline
+      case "_next":
+        return "/_next/{proxy+}";
+      case "_static":
+        return "/static/{proxy+}";
+      case "_public":
+        return "/public/{proxy+}";
       default:
         // handle pages at any subdir level
         // e.g. sls-next-build/post.js

--- a/packages/serverless-nextjs-plugin/classes/NextPage.js
+++ b/packages/serverless-nextjs-plugin/classes/NextPage.js
@@ -72,8 +72,6 @@ class NextPage {
         return "/_next/{proxy+}";
       case "_static":
         return "/static/{proxy+}";
-      case "_public":
-        return "/public/{proxy+}";
       default:
         // handle pages at any subdir level
         // e.g. sls-next-build/post.js

--- a/packages/serverless-nextjs-plugin/classes/__tests__/NextPage.test.js
+++ b/packages/serverless-nextjs-plugin/classes/__tests__/NextPage.test.js
@@ -400,7 +400,6 @@ describe("NextPage", () => {
       src             | handler             | route                 | id
       ${"_next.js"}   | ${"_next.render"}   | ${`/_next/{proxy+}`}  | ${"_next"}
       ${"_static.js"} | ${"_static.render"} | ${`/static/{proxy+}`} | ${"_static"}
-      ${"_public.js"} | ${"_public.render"} | ${`/public/{proxy+}`} | ${"_public"}
     `("should generate correct page", ({ src, handler, route, id }) => {
       const srcPath = path.join(PluginBuildDir.BUILD_DIR_NAME, src);
       const page = new NextPage(srcPath);

--- a/packages/serverless-nextjs-plugin/classes/__tests__/NextPage.test.js
+++ b/packages/serverless-nextjs-plugin/classes/__tests__/NextPage.test.js
@@ -394,4 +394,22 @@ describe("NextPage", () => {
       expect(httpHeadTwo.path).toBe("/another/custom/path/to/foo");
     });
   });
+
+  describe("when is offline handler page", () => {
+    it.each`
+      src             | handler             | route                 | id
+      ${"_next.js"}   | ${"_next.render"}   | ${`/_next/{proxy+}`}  | ${"_next"}
+      ${"_static.js"} | ${"_static.render"} | ${`/static/{proxy+}`} | ${"_static"}
+      ${"_public.js"} | ${"_public.render"} | ${`/public/{proxy+}`} | ${"_public"}
+    `("should generate correct page", ({ src, handler, route, id }) => {
+      const srcPath = path.join(PluginBuildDir.BUILD_DIR_NAME, src);
+      const page = new NextPage(srcPath);
+
+      expect(page.pageHandler).toBe(
+        path.posix.join(PluginBuildDir.BUILD_DIR_NAME, handler)
+      );
+      expect(page.pageRoute).toBe(route);
+      expect(page.pageId).toBe(id);
+    });
+  });
 });

--- a/packages/serverless-nextjs-plugin/index.js
+++ b/packages/serverless-nextjs-plugin/index.js
@@ -26,6 +26,16 @@ class ServerlessNextJsPlugin {
     this.printStackOutput = this.printStackOutput.bind(this);
     this.removePluginBuildDir = this.removePluginBuildDir.bind(this);
 
+    // If they're using serverless-offline, automagically wire it up
+    // to serve static assets correctly.
+    if (
+      // Can be null while running tests
+      serverless.service.plugins &&
+      serverless.service.plugins.includes("serverless-offline")
+    ) {
+      this.offline = { enabled: true };
+    }
+
     this.hooks = {
       "before:offline:start": this.build,
       "before:package:initialize": this.build,

--- a/packages/serverless-nextjs-plugin/lib/__tests__/getAssetsBucketName.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/getAssetsBucketName.test.js
@@ -86,4 +86,18 @@ describe("getAssetsBucketName", () => {
 
     expect(result).toEqual(bucketName);
   });
+
+  it("returns stored staticAssetsBucket if offline and set", () => {
+    expect.assertions(1);
+
+    const staticAssetsBucket = "my-assets";
+    plugin = new ServerlessPluginBuilder().build();
+    plugin.offline = {
+      staticAssetsBucket
+    };
+
+    const result = getAssetsBucketName.call(plugin);
+
+    expect(result).toEqual(staticAssetsBucket);
+  });
 });

--- a/packages/serverless-nextjs-plugin/lib/__tests__/writeAssetLambdas.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/writeAssetLambdas.test.js
@@ -1,0 +1,31 @@
+const fse = require("fs-extra");
+const path = require("path");
+const PluginBuildDir = require("../../classes/PluginBuildDir");
+const writeAssetLambdas = require("../writeAssetLambdas");
+
+jest.mock("fs-extra");
+
+describe("writeAssetLambdas", () => {
+  beforeEach(() => {
+    fse.copy.mockResolvedValue(null);
+  });
+  it("should copy offline handlers", async () => {
+    fse.readdir.mockResolvedValue(["_next.js"]);
+    const pluginBuildDir = new PluginBuildDir("test");
+    await writeAssetLambdas.call({
+      pluginBuildDir
+    });
+    expect(fse.copy).toBeCalledWith(
+      path.resolve(__dirname, "../../offline/_next.js"),
+      path.join(pluginBuildDir.buildDir, "_next.js")
+    );
+  });
+  it("should not copy test files", async () => {
+    fse.readdir.mockResolvedValue(["__tests__"]);
+    const pluginBuildDir = new PluginBuildDir("test");
+    await writeAssetLambdas.call({
+      pluginBuildDir
+    });
+    expect(fse.copy).not.toBeCalled();
+  });
+});

--- a/packages/serverless-nextjs-plugin/lib/getAssetsBucketName.js
+++ b/packages/serverless-nextjs-plugin/lib/getAssetsBucketName.js
@@ -1,6 +1,10 @@
 const parseNextConfiguration = require("./parseNextConfiguration");
 
 module.exports = function() {
+  if (this.offline && this.offline.staticAssetsBucket) {
+    return this.offline.staticAssetsBucket;
+  }
+
   const nextConfigDir = this.getPluginConfigValue("nextConfigDir");
   const staticDir = this.getPluginConfigValue("staticDir");
 

--- a/packages/serverless-nextjs-plugin/lib/serveFile.js
+++ b/packages/serverless-nextjs-plugin/lib/serveFile.js
@@ -1,0 +1,46 @@
+const fse = require("fs-extra");
+const path = require("path");
+const mime = require("mime");
+
+function notFound(reason) {
+  return {
+    statusCode: 404,
+    headers: {
+      "X-Serverless-Error": reason
+    }
+  };
+}
+
+const serveFile = async (nextDir, root, event) => {
+  const assetPath = path.resolve(
+    nextDir,
+    "..",
+    root,
+    event.pathParameters.proxy
+  );
+
+  if (!(await fse.pathExists(assetPath))) {
+    return notFound(`Unable to find file "${assetPath}".`);
+  }
+
+  try {
+    const buffer = await fse.readFile(assetPath);
+    return {
+      statusCode: 200,
+      body: buffer.toString("base64"),
+      isBase64Encoded: true,
+      headers: {
+        "Content-Type": mime.getType(assetPath)
+      }
+    };
+  } catch (e) {
+    return {
+      statusCode: 400,
+      headers: {
+        "X-Serverless-Error": JSON.stringify(e, Object.getOwnPropertyNames(e))
+      }
+    };
+  }
+};
+
+module.exports = serveFile;

--- a/packages/serverless-nextjs-plugin/lib/writeAssetLambdas.js
+++ b/packages/serverless-nextjs-plugin/lib/writeAssetLambdas.js
@@ -1,0 +1,23 @@
+const fse = require("fs-extra");
+const path = require("path");
+const NextPage = require("../classes/NextPage");
+
+const writeAssetLambdas = async function() {
+  const pluginBuildDir = this.pluginBuildDir;
+  const offlineHandlersDir = path.resolve(__dirname, "../offline/");
+  const files = await fse.readdir(offlineHandlersDir);
+
+  const pages = [];
+  for (const file of files) {
+    if (file === "__tests__") {
+      continue;
+    }
+    const source = path.resolve(offlineHandlersDir, file);
+    const destination = path.join(pluginBuildDir.buildDir, file);
+    await fse.copy(source, destination);
+    pages.push(new NextPage(path.join(pluginBuildDir.buildDir, file)));
+  }
+  return pages;
+};
+
+module.exports = writeAssetLambdas;

--- a/packages/serverless-nextjs-plugin/offline/__tests__/handlers.test.js
+++ b/packages/serverless-nextjs-plugin/offline/__tests__/handlers.test.js
@@ -9,7 +9,7 @@ describe.only("offline handlers", () => {
     mime.getType.mockImplementation(() => "application/test");
   });
 
-  ["_next", "_public", "_static"].forEach(handler => {
+  ["_next", "_static"].forEach(handler => {
     const handlerFunc = require(`../${handler}`);
     describe(handler, () => {
       it("should return 200 and contents for found file", async () => {

--- a/packages/serverless-nextjs-plugin/offline/__tests__/handlers.test.js
+++ b/packages/serverless-nextjs-plugin/offline/__tests__/handlers.test.js
@@ -1,0 +1,64 @@
+const fse = require("fs-extra");
+const mime = require("mime");
+
+jest.mock("fs-extra");
+jest.mock("mime");
+
+describe.only("offline handlers", () => {
+  beforeAll(() => {
+    mime.getType.mockImplementation(() => "application/test");
+  });
+
+  ["_next", "_public", "_static"].forEach(handler => {
+    const handlerFunc = require(`../${handler}`);
+    describe(handler, () => {
+      it("should return 200 and contents for found file", async () => {
+        const fileContents = Buffer.from("test");
+        fse.pathExists.mockResolvedValue(true);
+        fse.readFile.mockResolvedValue(fileContents);
+
+        const response = await handlerFunc.render({
+          pathParameters: { proxy: "text.js" }
+        });
+
+        expect(fse.pathExists).toBeCalled();
+        expect(fse.readFile).toBeCalled();
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toBe(fileContents.toString("base64"));
+        expect(response.headers["Content-Type"]).toBe("application/test");
+      });
+
+      it("should return 404 and reason for not found file", async () => {
+        fse.pathExists.mockResolvedValue(false);
+
+        const response = await handlerFunc.render({
+          pathParameters: { proxy: "text.js" }
+        });
+
+        expect(fse.pathExists).toBeCalled();
+        expect(fse.readFile).not.toBeCalled();
+
+        expect(response.statusCode).toBe(404);
+        expect(response.headers["X-Serverless-Error"]).toMatch(
+          /Unable to find file/
+        );
+      });
+
+      it("should return 400 and reason for exists but invalid file", async () => {
+        fse.pathExists.mockResolvedValue(true);
+        fse.readFile.mockRejectedValue("test");
+
+        const response = await handlerFunc.render({
+          pathParameters: { proxy: "text.js" }
+        });
+
+        expect(fse.pathExists).toBeCalled();
+        expect(fse.readFile).toBeCalled();
+
+        expect(response.statusCode).toBe(400);
+        expect(response.headers["X-Serverless-Error"]).toMatch(/test/);
+      });
+    });
+  });
+});

--- a/packages/serverless-nextjs-plugin/offline/_next.js
+++ b/packages/serverless-nextjs-plugin/offline/_next.js
@@ -1,0 +1,3 @@
+const serve = require("serverless-nextjs-plugin/lib/serveFile");
+
+module.exports.render = e => serve(__dirname, ".next", e);

--- a/packages/serverless-nextjs-plugin/offline/_public.js
+++ b/packages/serverless-nextjs-plugin/offline/_public.js
@@ -1,0 +1,3 @@
+const serve = require("serverless-nextjs-plugin/lib/serveFile");
+
+module.exports.render = e => serve(__dirname, "public", e);

--- a/packages/serverless-nextjs-plugin/offline/_public.js
+++ b/packages/serverless-nextjs-plugin/offline/_public.js
@@ -1,3 +1,0 @@
-const serve = require("serverless-nextjs-plugin/lib/serveFile");
-
-module.exports.render = e => serve(__dirname, "public", e);

--- a/packages/serverless-nextjs-plugin/offline/_static.js
+++ b/packages/serverless-nextjs-plugin/offline/_static.js
@@ -1,0 +1,3 @@
+const serve = require("serverless-nextjs-plugin/lib/serveFile");
+
+module.exports.render = e => serve(__dirname, "static", e);


### PR DESCRIPTION
Adds offline static support by adding a simple handler that acts a file proxy for the specific routes.

This is somewhat rough draft, but it was working well with my proof of concept app and the integration app.

Possible further changes could be moving all the logic into serveFile and consolidating the handler down to just something like `_assets.js`. 