### PR TITLE
Adding cache control to build assets

### DIFF
--- a/packages/serverless-nextjs-plugin/lib/__tests__/uploadStaticAssets.test.js
+++ b/packages/serverless-nextjs-plugin/lib/__tests__/uploadStaticAssets.test.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const fs = require("fs");
 const fse = require("fs-extra");
 const { when } = require("jest-when");
 const uploadStaticAssets = require("../uploadStaticAssets");
@@ -10,6 +11,7 @@ const uploadDirToS3Factory = require("../../utils/s3/upload");
 jest.mock("fs-extra");
 jest.mock("../../utils/s3/upload");
 jest.mock("../parseNextConfiguration");
+jest.mock("fs");
 
 describe("uploadStaticAssets", () => {
   let uploadDirToS3;
@@ -17,6 +19,7 @@ describe("uploadStaticAssets", () => {
   beforeEach(() => {
     uploadDirToS3 = jest.fn().mockResolvedValue();
     uploadDirToS3Factory.mockReturnValue(uploadDirToS3);
+    fs.readFileSync.mockResolvedValue("1hCeVQzuD6WJQAxuV3hwc");
   });
 
   it("does NOT upload build assets when there isn't a bucket available", () => {

--- a/packages/serverless-nextjs-plugin/lib/uploadStaticAssets.js
+++ b/packages/serverless-nextjs-plugin/lib/uploadStaticAssets.js
@@ -1,11 +1,15 @@
+const fs = require("fs");
 const fse = require("fs-extra");
 const path = require("path");
 const uploadDirToS3Factory = require("../utils/s3/upload");
 
 module.exports = async function() {
-  const uploadDirToS3 = uploadDirToS3Factory(this.providerRequest);
-
   let { nextConfiguration, staticAssetsBucket } = this.configuration;
+  const buildId = nextConfiguration.distDir // eslint-disable-next-line prettier/prettier
+    ? fs.readFileSync(path.join(this.nextConfigDir, nextConfiguration.distDir, "BUILD_ID"))
+    : null;
+
+  const uploadDirToS3 = uploadDirToS3Factory(this.providerRequest, buildId);
 
   const [bucketNameFromConfig, uploadBuildAssets] = this.getPluginConfigValues(
     "assetsBucketName",


### PR DESCRIPTION
Adds cache-control metadata to build assets. Infrastructure for adding cache-control for public and static folders can be used, however we can chat about how to implement configs for this in the serverless.yml config. This should address #40 