### PR TITLE
Add configuration for bucket name

### DIFF
--- a/packages/serverless-nextjs-component/README.md
+++ b/packages/serverless-nextjs-component/README.md
@@ -95,6 +95,19 @@ myNextApplication:
     domain: ["www", "example.com"] # [ sub-domain, domain ]
 ```
 
+### Custom bucket name
+
+To override the default generated bucket name provided by Serverless, configure your `bucketName` like the example below:
+
+```yml
+# serverless.yml
+
+myNextApplication:
+  component: serverless-next.js
+  inputs:
+    bucketName: my-next-application
+```
+
 ### Architecture
 
 ![architecture](./arch_no_grid.png)

--- a/packages/serverless-nextjs-component/__tests__/build.test.js
+++ b/packages/serverless-nextjs-component/__tests__/build.test.js
@@ -64,7 +64,9 @@ describe("build tests", () => {
   afterAll(cleanupFixtureDirectory(fixturePath));
 
   it("outputs next application url from cloudfront", () => {
-    expect(componentOutputs.appUrl).toEqual("https://cloudfrontdistrib.amazonaws.com");
+    expect(componentOutputs.appUrl).toEqual(
+      "https://cloudfrontdistrib.amazonaws.com"
+    );
   });
 
   it("outputs S3 bucket name", () => {

--- a/packages/serverless-nextjs-component/__tests__/build.test.js
+++ b/packages/serverless-nextjs-component/__tests__/build.test.js
@@ -64,9 +64,11 @@ describe("build tests", () => {
   afterAll(cleanupFixtureDirectory(fixturePath));
 
   it("outputs next application url from cloudfront", () => {
-    expect(componentOutputs).toEqual({
-      appUrl: "https://cloudfrontdistrib.amazonaws.com"
-    });
+    expect(componentOutputs.appUrl).toEqual("https://cloudfrontdistrib.amazonaws.com");
+  });
+
+  it("outputs S3 bucket name", () => {
+    expect(componentOutputs.bucketName).toEqual("bucket-xyz");
   });
 
   describe("Default build manifest", () => {

--- a/packages/serverless-nextjs-component/__tests__/custom-domain.test.js
+++ b/packages/serverless-nextjs-component/__tests__/custom-domain.test.js
@@ -59,8 +59,6 @@ describe("Custom domain", () => {
   });
 
   it("uses outputs custom domain url", async () => {
-    expect(componentOutputs).toEqual({
-      appUrl: "https://www.example.com"
-    });
+    expect(componentOutputs.appUrl).toEqual("https://www.example.com");
   });
 });

--- a/packages/serverless-nextjs-component/serverless.js
+++ b/packages/serverless-nextjs-component/serverless.js
@@ -159,7 +159,8 @@ class NextjsComponent extends Component {
     );
 
     const bucketOutputs = await bucket({
-      accelerated: true
+      accelerated: true,
+      name: inputs.bucketName
     });
 
     const uploadHtmlPages = Object.values(defaultBuildManifest.pages.html).map(
@@ -304,7 +305,8 @@ class NextjsComponent extends Component {
     }
 
     return {
-      appUrl
+      appUrl,
+      bucketName: bucketOutputs.name
     };
   }
 


### PR DESCRIPTION
Closes #145 by exposing a configuration option for the S3 bucket name the component creates.

Looks like the input isn't documented in the `@serverless/aws-s3` component, however the input configuration for `name` is used [here](https://github.com/serverless-components/aws-s3/blob/master/serverless.js#L27). If the bucket name isn't specified, the component generates a bucket name as it does currently.