### PR TITLE
Fixes response status code not being set properly

### DIFF
--- a/packages/serverless-nextjs-component/next-aws-cloudfront.js
+++ b/packages/serverless-nextjs-component/next-aws-cloudfront.js
@@ -104,10 +104,10 @@ const handler = event => {
 
   Object.defineProperty(res, "statusCode", {
     get() {
-      return response.statusCode;
+      return response.status;
     },
     set(statusCode) {
-      response.statusCode = statusCode;
+      response.status = statusCode;
     }
   });
 


### PR DESCRIPTION
Resolves #155 by using the `response.status` value instead of `response.statusCode`.

Previously, setting the value of `response.statusCode` didn't have an effect since CloudFront uses `response.status`. This meant that all routes returned a 200 status code even if the route did not exist.

It looks like `response.statusCode` might have been a typo since `statusCode` isn't an actual property on `response`.