### PR TITLE
Update AWS CloudFront component

### DIFF
--- a/packages/serverless-nextjs-component/README.md
+++ b/packages/serverless-nextjs-component/README.md
@@ -95,6 +95,19 @@ myNextApplication:
     domain: ["www", "example.com"] # [ sub-domain, domain ]
 ```
 
+### Custom bucket name
+
+To override the default generated bucket name provided by Serverless, configure your `bucketName` like the example below:
+
+```yml
+# serverless.yml
+
+myNextApplication:
+  component: serverless-next.js
+  inputs:
+    bucketName: my-next-application
+```
+
 ### Architecture
 
 ![architecture](./arch_no_grid.png)

--- a/packages/serverless-nextjs-component/__tests__/build.test.js
+++ b/packages/serverless-nextjs-component/__tests__/build.test.js
@@ -64,7 +64,9 @@ describe("build tests", () => {
   afterAll(cleanupFixtureDirectory(fixturePath));
 
   it("outputs next application url from cloudfront", () => {
-    expect(componentOutputs.appUrl).toEqual("https://cloudfrontdistrib.amazonaws.com");
+    expect(componentOutputs.appUrl).toEqual(
+      "https://cloudfrontdistrib.amazonaws.com"
+    );
   });
 
   it("outputs S3 bucket name", () => {

--- a/packages/serverless-nextjs-component/__tests__/build.test.js
+++ b/packages/serverless-nextjs-component/__tests__/build.test.js
@@ -64,9 +64,11 @@ describe("build tests", () => {
   afterAll(cleanupFixtureDirectory(fixturePath));
 
   it("outputs next application url from cloudfront", () => {
-    expect(componentOutputs).toEqual({
-      appUrl: "https://cloudfrontdistrib.amazonaws.com"
-    });
+    expect(componentOutputs.appUrl).toEqual("https://cloudfrontdistrib.amazonaws.com");
+  });
+
+  it("outputs S3 bucket name", () => {
+    expect(componentOutputs.bucketName).toEqual("bucket-xyz");
   });
 
   describe("Default build manifest", () => {

--- a/packages/serverless-nextjs-component/__tests__/custom-domain.test.js
+++ b/packages/serverless-nextjs-component/__tests__/custom-domain.test.js
@@ -59,8 +59,6 @@ describe("Custom domain", () => {
   });
 
   it("uses outputs custom domain url", async () => {
-    expect(componentOutputs).toEqual({
-      appUrl: "https://www.example.com"
-    });
+    expect(componentOutputs.appUrl).toEqual("https://www.example.com");
   });
 });

--- a/packages/serverless-nextjs-component/package.json
+++ b/packages/serverless-nextjs-component/package.json
@@ -22,7 +22,7 @@
     "node": ">=10.11.0"
   },
   "dependencies": {
-    "@serverless/aws-cloudfront": "^3.2.0",
+    "@serverless/aws-cloudfront": "^5.0.0",
     "@serverless/aws-lambda": "^3.0.0",
     "@serverless/aws-s3": "^3.1.0",
     "@serverless/core": "^1.0.0",

--- a/packages/serverless-nextjs-component/serverless.js
+++ b/packages/serverless-nextjs-component/serverless.js
@@ -159,7 +159,8 @@ class NextjsComponent extends Component {
     );
 
     const bucketOutputs = await bucket({
-      accelerated: true
+      accelerated: true,
+      name: inputs.bucketName
     });
 
     const uploadHtmlPages = Object.values(defaultBuildManifest.pages.html).map(
@@ -304,7 +305,8 @@ class NextjsComponent extends Component {
     }
 
     return {
-      appUrl
+      appUrl,
+      bucketName: bucketOutputs.name
     };
   }
 


### PR DESCRIPTION
Upgrading to the latest CloudFront plugin allows for cookie forwarding and other options.

It may be worth considering exposing some inputs (with sensible defaults) to further configure CloudFront, but for now this will address the issue described in #154.