### PR TITLE
Forward cookies and query strings to edge lambda

### DIFF
--- a/packages/serverless-nextjs-component/__tests__/build.test.js
+++ b/packages/serverless-nextjs-component/__tests__/build.test.js
@@ -237,7 +237,7 @@ describe("build tests", () => {
         defaults: {
           allowedHttpMethods: expect.any(Array),
           queryString: true,
-          cookies: 'all',
+          cookies: "all",
           ttl: 5,
           "lambda@edge": {
             "origin-request":

--- a/packages/serverless-nextjs-component/__tests__/build.test.js
+++ b/packages/serverless-nextjs-component/__tests__/build.test.js
@@ -236,6 +236,8 @@ describe("build tests", () => {
       expect(mockCloudFront).toBeCalledWith({
         defaults: {
           allowedHttpMethods: expect.any(Array),
+          queryString: true,
+          cookies: 'all',
           ttl: 5,
           "lambda@edge": {
             "origin-request":

--- a/packages/serverless-nextjs-component/serverless.js
+++ b/packages/serverless-nextjs-component/serverless.js
@@ -282,6 +282,8 @@ class NextjsComponent extends Component {
       defaults: {
         ttl: 5,
         allowedHttpMethods: ["HEAD", "GET"],
+        cookies: "all",
+        queryString: true,
         "lambda@edge": {
           "origin-request": `${defaultEdgeLambdaOutputs.arn}:${defaultEdgeLambdaPublishOutputs.version}`
         }


### PR DESCRIPTION
This PR adds forwarding for cookies and query strings since aren't forwarded in the CloudFront component by default. Fixes #154.