### PR TITLE
Fix calling `res.end` in `getInitialProps`

### DIFF
--- a/packages/serverless-nextjs-component/next-aws-cloudfront.js
+++ b/packages/serverless-nextjs-component/next-aws-cloudfront.js
@@ -101,6 +101,7 @@ const handler = event => {
   req.push(null);
 
   const res = new Stream();
+  res.finished = false;
 
   Object.defineProperty(res, "statusCode", {
     get() {
@@ -128,6 +129,7 @@ const handler = event => {
   const responsePromise = new Promise(resolve => {
     res.end = text => {
       if (text) res.write(text);
+      res.finished = true;
       response.body = Buffer.from(response.body).toString("base64");
       response.headers = toCloudFrontHeaders(res.headers);
 


### PR DESCRIPTION
A common way to do redirections in `getInitialProps` is to use `res.writeHead` and then call `res.end`. When doing this the lambda handler would end up resolving twice and causing an error. This is because next checks if `res.finished` is set before ending the response, but `next-aws-cloudfront` never sets it. This adds `res.finished` and sets it to true in `res.end`.