### PR TITLE
Fix cloudfront default cache behavior

### DIFF
--- a/packages/serverless-nextjs-component/__tests__/deploy.test.js
+++ b/packages/serverless-nextjs-component/__tests__/deploy.test.js
@@ -108,8 +108,10 @@ describe("deploy tests", () => {
       expect(mockCloudFront).toBeCalledWith({
         defaults: {
           allowedHttpMethods: expect.any(Array),
-          queryString: true,
-          cookies: "all",
+          forward: {
+            queryString: true,
+            cookies: "all"
+          },
           ttl: 5,
           "lambda@edge": {
             "origin-request":

--- a/packages/serverless-nextjs-component/serverless.js
+++ b/packages/serverless-nextjs-component/serverless.js
@@ -347,8 +347,10 @@ class NextjsComponent extends Component {
       defaults: {
         ttl: 5,
         allowedHttpMethods: ["HEAD", "GET"],
-        cookies: "all",
-        queryString: true,
+        forward: {
+          cookies: "all",
+          queryString: true
+        },
         "lambda@edge": {
           "origin-request": `${defaultEdgeLambdaOutputs.arn}:${defaultEdgeLambdaPublishOutputs.version}`
         }


### PR DESCRIPTION
This should fix query and cookies for cloudfront default cache behaviour according to `@serverless/aws-cloudfront` [docs](https://github.com/serverless-components/aws-cloudfront#3-configure)

I need some instructions to run and test it but it should work