### PR TITLE
ignore subdomain if not present

### DIFF
--- a/packages/serverless-nextjs-component/README.md
+++ b/packages/serverless-nextjs-component/README.md
@@ -86,7 +86,18 @@ $ serverless
 
 In most cases you wouldn't want to use CloudFront's distribution domain to access your application. Instead, you can specify a custom domain name.
 
-First, make sure you've purchased your domain within Route53. Then simply configure your `subdomain` and `domain` like the example below.
+Make sure you've purchased your `domain` within Route53: 
+
+```yml
+# serverless.yml
+
+myNextApplication:
+  component: serverless-next.js
+  inputs:
+    domain: "example.com"
+```
+
+You can also configure a `subdomain`:
 
 ```yml
 # serverless.yml

--- a/packages/serverless-nextjs-component/examples/multiple-instance-environment/env-prod
+++ b/packages/serverless-nextjs-component/examples/multiple-instance-environment/env-prod
@@ -1,1 +1,1 @@
-domain=['myapp.com']
+domain='myapp.com'

--- a/packages/serverless-nextjs-component/examples/multiple-instance-environment/env-staging
+++ b/packages/serverless-nextjs-component/examples/multiple-instance-environment/env-staging
@@ -1,1 +1,2 @@
-domain=['dev', 'myapp.com']
+domain='myapp.com'
+subdomain='dev'

--- a/packages/serverless-nextjs-component/examples/multiple-instance-environment/serverless.yml
+++ b/packages/serverless-nextjs-component/examples/multiple-instance-environment/serverless.yml
@@ -1,4 +1,6 @@
 myNextApp:
  component: "../../"
  inputs:
-  domain: ${env.domain}
+  domain:
+    - ${env.subdomain}
+    - ${env.domain}

--- a/packages/serverless-nextjs-component/lib/obtainDomains.js
+++ b/packages/serverless-nextjs-component/lib/obtainDomains.js
@@ -1,0 +1,19 @@
+// Determine domain and subdomain assuming either a string representing a domain
+// or an array representing both a domain and subdomain
+module.exports = domains => {
+  if (typeof domains === "string") {
+    return { domain: domains, subdomain: "www" };
+  }
+
+  // Assumes an array of size 1 or 2. If size 1, then first element is domain
+  // and subdomain is hardcoded to "www" (which @serverless/domain will "unshift" to root).
+  // if size 2, then first element is subdomain, second element is domain
+  if (domains instanceof Array && domains.length) {
+    return {
+      domain: domains.length > 1 ? domains[1] : domains[0],
+      subdomain: domains.length > 1 && domains[0] ? domains[0] : "www"
+    };
+  }
+
+  return { domain: undefined, subdomain: undefined };
+};

--- a/packages/serverless-nextjs-component/serverless.js
+++ b/packages/serverless-nextjs-component/serverless.js
@@ -4,6 +4,7 @@ const path = require("path");
 const execa = require("execa");
 
 const isDynamicRoute = require("./lib/isDynamicRoute");
+const obtainDomains = require("./lib/obtainDomains");
 const expressifyDynamicRoute = require("./lib/expressifyDynamicRoute");
 const pathToRegexStr = require("./lib/pathToRegexStr");
 const { DEFAULT_LAMBDA_CODE_DIR, API_LAMBDA_CODE_DIR } = require("./constants");
@@ -368,16 +369,17 @@ class NextjsComponent extends Component {
 
     let appUrl = cloudFrontOutputs.url;
 
-    if (inputs.domain instanceof Array) {
-      const domain = await this.load("@serverless/domain");
-      const domainOutputs = await domain({
+    // Create domain
+    const { domain, subdomain } = obtainDomains(inputs.domain);
+    if (domain) {
+      const domainComponent = await this.load("@serverless/domain");
+      const domainOutputs = await domainComponent({
         privateZone: false,
-        domain: inputs.domain[1],
+        domain,
         subdomains: {
-          [inputs.domain[0]]: cloudFrontOutputs
+          [subdomain]: cloudFrontOutputs
         }
       });
-
       appUrl = domainOutputs.domains[0];
     }
 


### PR DESCRIPTION
This solves #228.

It alters the code so that it does not assume an array with two elements, with the first being a subdomain. If subdomain is not present, it will be hard coded to "www", which will not be needed for root if present (see https://github.com/serverless-components/domain/blob/master/serverless.js#L213)

I believe that this will make things more intuitive