### PR TITLE
fix cache header for s3 files

### DIFF
--- a/packages/serverless-nextjs-component/__tests__/assets.test.js
+++ b/packages/serverless-nextjs-component/__tests__/assets.test.js
@@ -43,7 +43,7 @@ describe("Assets Tests", () => {
     it("uploads client build assets", () => {
       expect(mockS3Upload).toBeCalledWith({
         dir: path.join(fixturePath, ".next/static"),
-        cacheControl: "Cache-Control': 'public, max-age=31536000, immutable",
+        cacheControl: "public, max-age=31536000, immutable",
         keyPrefix: "_next/static"
       });
     });

--- a/packages/serverless-nextjs-component/serverless.js
+++ b/packages/serverless-nextjs-component/serverless.js
@@ -294,7 +294,7 @@ class NextjsComponent extends Component {
       bucket.upload({
         dir: join(nextConfigPath, ".next/static"),
         keyPrefix: "_next/static",
-        cacheControl: "Cache-Control': 'public, max-age=31536000, immutable"
+        cacheControl: "public, max-age=31536000, immutable"
       }),
       ...uploadHtmlPages
     ];


### PR DESCRIPTION
I noticed the Cache-Control metadata information in the files uploaded to s3 has a typo:

![S3_Management_Console](https://user-images.githubusercontent.com/1280277/69202300-1348eb80-0af6-11ea-871c-541725fd8420.png)

browser headers:
![SSR_Page](https://user-images.githubusercontent.com/1280277/69202316-21970780-0af6-11ea-81aa-a7f2af04caf2.png)


This PR fixes that, as can be seen here:
![S3_Management_Console](https://user-images.githubusercontent.com/1280277/69202351-3bd0e580-0af6-11ea-9f70-fdb4ba3346d3.png)
![SSR_Page](https://user-images.githubusercontent.com/1280277/69202356-425f5d00-0af6-11ea-9f33-b119727dc479.png)

cheers!