### PR TITLE
Clarify that AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY can be set as environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ myNextApplication:
   component: serverless-next.js
 ```
 
-Set your aws credentials in a `.env` file:
+Set your aws credentials in a `.env` file (or set them as environment variables):
 
 ```bash
 AWS_ACCESS_KEY_ID=accesskey


### PR DESCRIPTION
Otherwise, it sounds as if you _have_ to create a `.env` file (which is inconvenient for CI purposes).