### PR TITLE
Convert non-Buffer response.body to Buffer

### DIFF
--- a/packages/next-aws-lambda/lib/compatLayer.js
+++ b/packages/next-aws-lambda/lib/compatLayer.js
@@ -78,7 +78,7 @@ const reqResMapper = (event, callback) => {
   };
   res.write = chunk => {
     response.body = Buffer.concat([
-      response.body,
+      Buffer.isBuffer(response.body) ? response.body : Buffer.from(response.body),
       Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
     ]);
   };

--- a/packages/next-aws-lambda/lib/compatLayer.js
+++ b/packages/next-aws-lambda/lib/compatLayer.js
@@ -78,7 +78,9 @@ const reqResMapper = (event, callback) => {
   };
   res.write = chunk => {
     response.body = Buffer.concat([
-      Buffer.isBuffer(response.body) ? response.body : Buffer.from(response.body),
+      Buffer.isBuffer(response.body)
+        ? response.body
+        : Buffer.from(response.body),
       Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
     ]);
   };


### PR DESCRIPTION
I noticed intermittent errors in CloudWatch after deploying my Next.js app with `serverless-nextjs-plugin`. The stacktrace pointed at this line, so I added a guard to ensure `response.body` wouldn't cause an exception with `Buffer.concat`. I verified the errors no longer occur after redeploying with this fork.

Not sure why it only happened intermittently, but let me know if I missed something obvious. Thanks!

```
ERROR	TypeError [ERR_INVALID_ARG_TYPE]: The "list[0]" argument must be one of type Array, Buffer, or Uint8Array. Received type string
    at Function.concat (buffer.js:480:13)
    at Stream.res.write.chunk [as write] (/var/task/node_modules/next-aws-lambda/lib/compatLayer.js:80:28)
    at Stream.text [as end] (/var/task/node_modules/next-aws-lambda/lib/compatLayer.js:99:19)
    at sendHTML (/var/task/sls-next-build/<redacted>)
    ...
```