### PR TITLE
Fix for empty req url

### DIFF
--- a/packages/next-aws-lambda/lib/__tests__/compatLayer.request.test.js
+++ b/packages/next-aws-lambda/lib/__tests__/compatLayer.request.test.js
@@ -31,6 +31,17 @@ describe("compatLayer.request", () => {
     expect(req.url).toEqual("/");
   });
 
+  it("request url path just stage name no trailing slash", () => {
+    const { req } = create({
+      requestContext: {
+        stage: "dev",
+        path: "/dev",
+      }
+    });
+
+    expect(req.url).toEqual("/");
+  });
+
   it("querystring /?x=42", () => {
     const { req } = create({
       requestContext: {

--- a/packages/next-aws-lambda/lib/__tests__/compatLayer.request.test.js
+++ b/packages/next-aws-lambda/lib/__tests__/compatLayer.request.test.js
@@ -35,7 +35,7 @@ describe("compatLayer.request", () => {
     const { req } = create({
       requestContext: {
         stage: "dev",
-        path: "/dev",
+        path: "/dev"
       }
     });
 

--- a/packages/next-aws-lambda/lib/compatLayer.js
+++ b/packages/next-aws-lambda/lib/compatLayer.js
@@ -15,7 +15,7 @@ const reqResMapper = (event, callback) => {
   req.url = (event.requestContext.path || event.path || "").replace(
     new RegExp("^/" + event.requestContext.stage),
     ""
-  );
+  ) || "/";
 
   let qs = "";
 

--- a/packages/next-aws-lambda/lib/compatLayer.js
+++ b/packages/next-aws-lambda/lib/compatLayer.js
@@ -12,10 +12,11 @@ const reqResMapper = (event, callback) => {
   let responsePromise;
 
   const req = new Stream.Readable();
-  req.url = (event.requestContext.path || event.path || "").replace(
-    new RegExp("^/" + event.requestContext.stage),
-    ""
-  ) || "/";
+  req.url =
+    (event.requestContext.path || event.path || "").replace(
+      new RegExp("^/" + event.requestContext.stage),
+      ""
+    ) || "/";
 
   let qs = "";
 


### PR DESCRIPTION
To fix #314 

`req.url` should never be an empty string, so default to `"/"`.