### PR TITLE
Fix the issue with TypeError hasHeader is not a function

### DIFF
--- a/packages/next-aws-lambda/lib/__tests__/compatLayer.response.test.js
+++ b/packages/next-aws-lambda/lib/__tests__/compatLayer.response.test.js
@@ -265,6 +265,19 @@ describe("compatLayer.response", () => {
     });
   });
 
+  it("hasHeader", () => {
+    const { res } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+    res.setHeader("x-custom-1", "1");
+
+    expect(res.hasHeader("x-custom-1")).toBe(true);
+    expect(res.hasHeader("x-custom-2")).toBe(false);
+  });
+
   it(`res.write('ok')`, done => {
     const { res } = create(
       {

--- a/packages/next-aws-lambda/lib/compatLayer.js
+++ b/packages/next-aws-lambda/lib/compatLayer.js
@@ -97,6 +97,9 @@ const reqResMapper = (event, callback) => {
   res.getHeaders = () => {
     return res.headers;
   };
+  res.hasHeader = name => {
+    return !!res.getHeader(name);
+  };
 
   const onResEnd = (callback, resolve) => text => {
     if (text) res.write(text);


### PR DESCRIPTION
When deploying to netlify or AWS (both depend on AWS-lambda)
The SSR components (using `getServerSideProps` fails with the following
error:
```
  ERROR	TypeError: res.hasHeader is not a function
    at sendPayload (/var/task/pages/test.js:5787:41)
    at renderReqToHTML (/var/task/pages/test.js:1773:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Module.render (/var/task/pages/test.js:1816:22)
```
This is caused by nextjs trying to use the default node `hasHeader`
method here: https://github.com/zeit/next.js/blob/v9.3.1/packages/next/next-server/server/send-payload.ts#L25

This commit fix the issue reported here: https://github.com/zeit/next.js/issues/11223
which I could verify also happening on our stack by adding the method
that mimics the nodeJS method (using `res.getHeader(name)` internally wrapping it
in boolean response)