### PR TITLE
Bug/header-name case-sensitive

### DIFF
--- a/packages/next-aws-lambda/lib/__tests__/compatLayer.response.test.js
+++ b/packages/next-aws-lambda/lib/__tests__/compatLayer.response.test.js
@@ -278,6 +278,34 @@ describe("compatLayer.response", () => {
     expect(res.hasHeader("x-custom-2")).toBe(false);
   });
 
+  it("case insensitive headers", () => {
+    const { res } = create({
+      requestContext: {
+        path: "/"
+      },
+      headers: {}
+    });
+    res.setHeader("x-custom-1", "1");
+    res.setHeader("X-CUSTOM-2", "2");
+    res.setHeader("X-cUsToM-3", "3");
+
+    expect(res.getHeader("X-CUSTOM-1")).toEqual("1");
+    expect(res.getHeader("x-custom-2")).toEqual("2");
+    expect(res.getHeader("x-CuStOm-3")).toEqual("3");
+
+    expect(res.getHeaders()).toEqual({
+      "x-custom-1": "1",
+      "x-custom-2": "2",
+      "x-custom-3": "3"
+    });
+
+    res.removeHeader("X-CUSTOM-1");
+    res.removeHeader("x-custom-2");
+    res.removeHeader("x-CUSTom-3");
+
+    expect(res.getHeaders()).toEqual({});
+  });
+
   it(`res.write('ok')`, done => {
     const { res } = create(
       {

--- a/packages/next-aws-lambda/lib/compatLayer.js
+++ b/packages/next-aws-lambda/lib/compatLayer.js
@@ -86,10 +86,10 @@ const reqResMapper = (event, callback) => {
     ]);
   };
   res.setHeader = (name, value) => {
-    res.headers[name] = value;
+    res.headers[name.toLowerCase()] = value;
   };
   res.removeHeader = name => {
-    delete res.headers[name];
+    delete res.headers[name.toLowerCase()];
   };
   res.getHeader = name => {
     return res.headers[name.toLowerCase()];


### PR DESCRIPTION
Previously the following behaviour could be observed:
```
res.setHeader("X-CUSTOM", "VAL")
res.getHeader("X-CUSTOM") => null
res.hasHeader("X-CUSTOM") => false

res.setHeader("x-custom", "val")
res.getHeader("X-CUSTOM") => "val"
res.hasHeader("X-CUSTOM") => true
```
There is no way of accessing a header that isn't set in lower case,
This fixes the issue by always storing the header name as lower case,
allowing a similar behaviour to node HTTP ResponseObject behaviour
 - https://nodejs.org/api/http.html#http_request_getheader_name
 - https://nodejs.org/api/http.html#http_request_removeheader_name
 - https://nodejs.org/api/http.html#http_request_setheader_name_value