### PR TITLE
Add let to iteration in default-lambda-handler

### DIFF
--- a/packages/serverless-nextjs-component/default-lambda-handler.js
+++ b/packages/serverless-nextjs-component/default-lambda-handler.js
@@ -13,7 +13,7 @@ const router = manifest => {
       return ssr.nonDynamic[path];
     }
 
-    for (route in allDynamicRoutes) {
+    for (let route in allDynamicRoutes) {
       const { file, regex } = allDynamicRoutes[route];
 
       const re = new RegExp(regex, "i");


### PR DESCRIPTION
Removes the warning viewing in the lambda console.

Using `let` to match https://github.com/danielcondemarin/serverless-next.js/blob/master/packages/serverless-nextjs-component/api-lambda-handler.js#L16 although I think both can be `const`?