### PR TITLE
Fix the issue with TypeError hasHeader is not a function

### DIFF
--- a/packages/serverless-nextjs-component/__tests__/next-aws-cloudfront.response.test.js
+++ b/packages/serverless-nextjs-component/__tests__/next-aws-cloudfront.response.test.js
@@ -223,6 +223,19 @@ describe("Response Tests", () => {
     });
   });
 
+  it("hasHeader", () => {
+    const { res } = create({
+      request: {
+        path: "/",
+        headers: {}
+      }
+    });
+    res.setHeader("x-custom-1", "1");
+
+    expect(res.hasHeader("x-custom-1")).toBe(true);
+    expect(res.hasHeader("x-custom-2")).toBe(false);
+  });
+
   it(`res.write('ok')`, () => {
     const { res, responsePromise } = create({
       request: {

--- a/packages/serverless-nextjs-component/__tests__/next-aws-cloudfront.response.test.js
+++ b/packages/serverless-nextjs-component/__tests__/next-aws-cloudfront.response.test.js
@@ -236,6 +236,34 @@ describe("Response Tests", () => {
     expect(res.hasHeader("x-custom-2")).toBe(false);
   });
 
+  it("case insensitive headers", () => {
+    const { res } = create({
+      request: {
+        path: "/",
+        headers: {}
+      }
+    });
+    res.setHeader("x-custom-1", "1");
+    res.setHeader("X-CUSTOM-2", "2");
+    res.setHeader("X-cUsToM-3", "3");
+
+    expect(res.getHeader("X-CUSTOM-1")).toEqual("1");
+    expect(res.getHeader("x-custom-2")).toEqual("2");
+    expect(res.getHeader("x-CuStOm-3")).toEqual("3");
+
+    expect(res.getHeaders()).toEqual({
+      "x-custom-1": "1",
+      "x-custom-2": "2",
+      "x-custom-3": "3"
+    });
+
+    res.removeHeader("X-CUSTOM-1");
+    res.removeHeader("x-custom-2");
+    res.removeHeader("x-CUSTom-3");
+
+    expect(res.getHeaders()).toEqual({});
+  });
+
   it(`res.write('ok')`, () => {
     const { res, responsePromise } = create({
       request: {

--- a/packages/serverless-nextjs-component/next-aws-cloudfront.js
+++ b/packages/serverless-nextjs-component/next-aws-cloudfront.js
@@ -187,6 +187,9 @@ const handler = event => {
   res.getHeaders = () => {
     return res.headers;
   };
+  res.hasHeader = name => {
+    return !!res.getHeader(name);
+  };
 
   return {
     req,

--- a/packages/serverless-nextjs-component/next-aws-cloudfront.js
+++ b/packages/serverless-nextjs-component/next-aws-cloudfront.js
@@ -176,10 +176,10 @@ const handler = event => {
   });
 
   res.setHeader = (name, value) => {
-    res.headers[name] = value;
+    res.headers[name.toLowerCase()] = value;
   };
   res.removeHeader = name => {
-    delete res.headers[name];
+    delete res.headers[name.toLowerCase()];
   };
   res.getHeader = name => {
     return res.headers[name.toLowerCase()];

--- a/packages/serverless-nextjs-component/package-lock.json
+++ b/packages/serverless-nextjs-component/package-lock.json
@@ -1463,9 +1463,9 @@
       }
     },
     "next-aws-lambda": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/next-aws-lambda/-/next-aws-lambda-2.3.6.tgz",
-      "integrity": "sha512-HZsKU4L/4szH3X6jeBQWpf1NEfMK5tkZny10oboGN6Hw2wjJkqLoAA09/i3GWp0zusXy2j0Ydt7QrNbshotNJA=="
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/next-aws-lambda/-/next-aws-lambda-2.3.8.tgz",
+      "integrity": "sha512-ABa3JEPZPxFU/NQKmUuOhAByih8XBNtss0DgBa/1wGXt0OhdCZaTfbY1Un3xm8PGkU7nfpI4/QLZysUfbieA5g=="
     },
     "normalize-path": {
       "version": "3.0.0",


### PR DESCRIPTION
When deploying to netlify or AWS (both depend on AWS-lambda)
The SSR components (using `getServerSideProps` fails with the following
error:
```
  ERROR	TypeError: res.hasHeader is not a function
    at sendPayload (/var/task/pages/test.js:5787:41)
    at renderReqToHTML (/var/task/pages/test.js:1773:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Module.render (/var/task/pages/test.js:1816:22)
```
This is caused by nextjs trying to use the default node `hasHeader`
method here: https://github.com/zeit/next.js/blob/v9.3.1/packages/next/next-server/server/send-payload.ts#L25

This commit fix the issue reported here: zeit/next.js#11223
which I could verify also happening on our stack by adding the method
that mimics the nodeJS method (using `res.getHeader(name)` internally wrapping it
in boolean response)

Previously fixed for next-aws-lambda in #329
also fix the header inconsistencies previously fixed for next-aws-lambda in #331 