### PR TITLE
Allow setting of additional lambda triggers for default and api

### DIFF
--- a/packages/serverless-component/README.md
+++ b/packages/serverless-component/README.md
@@ -111,7 +111,11 @@ myNextApplication:
           headers: [CloudFront-Is-Desktop-Viewer, CloudFront-Is-Mobile-Viewer, CloudFront-Is-Tablet-Viewer]
         lambda@edge:
           viewer-response: lambdaarn:version
-      api: # options for lambdas that handle API request
+      api: # options for lambdas that handle API
+        ttl: 10
+      static: # options for user static assets
+        ttl: 10
+      next: # options for build assets
         ttl: 10
       origins: # options for custom origins and behaviors
         - url: /static

--- a/packages/serverless-component/README.md
+++ b/packages/serverless-component/README.md
@@ -109,6 +109,8 @@ myNextApplication:
       defaults: # options for lambda that handle SSR
         forward:
           headers: [CloudFront-Is-Desktop-Viewer, CloudFront-Is-Mobile-Viewer, CloudFront-Is-Tablet-Viewer]
+        lambda@edge:
+          viewer-response: lambdaarn:version
       api: # options for lambdas that handle API request
         ttl: 10
       origins: # options for custom origins and behaviors

--- a/packages/serverless-component/__tests__/custom-inputs.test.js
+++ b/packages/serverless-component/__tests__/custom-inputs.test.js
@@ -245,17 +245,47 @@ describe("Custom inputs", () => {
   describe.each([
     [undefined, {}], // no input
     [{}, {}], // empty input
+    // Ignore origin-requests
     [
-      { defaults: { ttl: 500, "lambda@edge": "ignored value" } },
-      { defaults: { ttl: 500 } } // expecting lambda@edge value to be ignored
+      {
+        defaults: {
+          ttl: 500,
+          "lambda@edge": { "origin-request": "ignored value" }
+        }
+      },
+      { defaults: { ttl: 500 } } // expecting lambda@edge origin-request to be ignored
+    ],
+    // Allow other lamdba@edge types
+    [
+      {
+        defaults: {
+          ttl: 500,
+          "lambda@edge": { "origin-response": "used value" }
+        }
+      },
+      {
+        defaults: {
+          ttl: 500,
+          "lambda@edge": { "origin-response": "used value" }
+        }
+      }
     ],
     [
       { defaults: { forward: { headers: "X" } } },
       { defaults: { forward: { headers: "X" } } }
     ],
     [
-      { api: { ttl: 500, "lambda@edge": "ignored value" } },
-      { api: { ttl: 500 } } // expecting lambda@edge value to be ignored
+      {
+        api: {
+          ttl: 500,
+          "lambda@edge": { "origin-request": "ignored value" }
+        }
+      },
+      { api: { ttl: 500 } } // expecting lambda@edge origin-request to be ignored
+    ],
+    [
+      { api: { ttl: 500, "lambda@edge": { "origin-response": "used value" } } },
+      { api: { ttl: 500, "lambda@edge": { "origin-response": "used value" } } }
     ],
     [
       {
@@ -292,7 +322,8 @@ describe("Custom inputs", () => {
         },
         "lambda@edge": {
           "origin-request":
-            "arn:aws:lambda:us-east-1:123456789012:function:my-func:v1"
+            "arn:aws:lambda:us-east-1:123456789012:function:my-func:v1",
+          ...defaultCloudfrontInputs["lambda@edge"]
         }
       },
       origins: [
@@ -310,11 +341,12 @@ describe("Custom inputs", () => {
                 "PATCH"
               ],
               ttl: 0,
+              ...apiCloudfrontInputs,
               "lambda@edge": {
                 "origin-request":
-                  "arn:aws:lambda:us-east-1:123456789012:function:my-func:v1"
-              },
-              ...apiCloudfrontInputs
+                  "arn:aws:lambda:us-east-1:123456789012:function:my-func:v1",
+                ...apiCloudfrontInputs["lambda@edge"]
+              }
             },
             "static/*": { ttl: 86400 }
           },

--- a/packages/serverless-component/serverless.js
+++ b/packages/serverless-component/serverless.js
@@ -253,6 +253,7 @@ class NextjsComponent extends Component {
         ...apiCloudfrontInputs,
         // lambda@edge key is last and therefore cannot be overridden
         "lambda@edge": {
+          ...(apiCloudfrontInputs["lambda@edge"] || {}),
           "origin-request": `${apiEdgeLambdaOutputs.arn}:${apiEdgeLambdaPublishOutputs.version}`
         }
       };
@@ -296,6 +297,7 @@ class NextjsComponent extends Component {
         },
         // lambda@edge key is last and therefore cannot be overridden
         "lambda@edge": {
+          ...(defaultCloudfrontInputs["lambda@edge"] || {}),
           "origin-request": `${defaultEdgeLambdaOutputs.arn}:${defaultEdgeLambdaPublishOutputs.version}`
         }
       },

--- a/packages/serverless-component/serverless.js
+++ b/packages/serverless-component/serverless.js
@@ -176,16 +176,22 @@ class NextjsComponent extends Component {
       []
     ).map(expandRelativeUrls);
 
+    const nextCloudfrontInputs =
+      (inputs.cloudfront && inputs.cloudfront.next) || {};
+    const staticCloudfrontInputs =
+      (inputs.cloudfront && inputs.cloudfront.static) || {};
     const cloudFrontOrigins = [
       {
         url: bucketUrl,
         private: true,
         pathPatterns: {
           "_next/*": {
-            ttl: 86400
+            ttl: 86400,
+            ...nextCloudfrontInputs
           },
           "static/*": {
-            ttl: 86400
+            ttl: 86400,
+            ...staticCloudfrontInputs
           }
         }
       },


### PR DESCRIPTION
Allow passing of additional lambda triggers to default/api. Note it still overwrites any `origin-request` sent through.

```yaml
    cloudfront:
      defaults: # options for lambda that handle SSR
        lambda@edge:
          viewer-response: lambdaarn:version
      api:
        lambda@edge:
          viewer-response: lambdaarn:version
```