### PR TITLE
Copy the properties of http.IncomingMessage.prototype to request object by deep cloning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sls-next-build
 .DS_Store
 yarn.lock
 dist
+.vscode

--- a/packages/apigw-lambda-compat/lib/__tests__/compatLayer.request.test.js
+++ b/packages/apigw-lambda-compat/lib/__tests__/compatLayer.request.test.js
@@ -1,4 +1,5 @@
 const create = require("../compatLayer");
+const http = require("http");
 
 describe("compatLayer.request", () => {
   it("request url path", () => {
@@ -275,5 +276,34 @@ describe("compatLayer.request", () => {
 
     expect(req.connection).toEqual({});
     done();
+  });
+
+  it("request preserve http.IncomingMessage.prototype property", () => {
+    const exampleProperty = "I'm an example property";
+    http.IncomingMessage.prototype.exampleProperty = exampleProperty;
+    const { req } = create({
+      requestContext: {
+        path: ""
+      }
+    });
+
+    expect(typeof req.exampleProperty !== "undefined").toEqual(true);
+    expect(req.exampleProperty).toEqual(exampleProperty);
+  });
+
+  it("request preserve http.IncomingMessage.prototype function", () => {
+    const exampleFunction = function() {
+      return "I'm an example function.";
+    };
+    http.IncomingMessage.prototype.exampleFunction = exampleFunction;
+    const { req } = create({
+      requestContext: {
+        path: ""
+      }
+    });
+
+    expect(typeof req.exampleFunction === "function").toEqual(true);
+    expect(req.exampleFunction()).toEqual(exampleFunction());
+    expect(req.exampleFunction.toString()).toEqual(exampleFunction.toString());
   });
 });

--- a/packages/apigw-lambda-compat/lib/compatLayer.js
+++ b/packages/apigw-lambda-compat/lib/compatLayer.js
@@ -1,5 +1,6 @@
 const Stream = require("stream");
 const queryString = require("querystring");
+const http = require("http");
 
 const reqResMapper = (event, callback) => {
   const base64Support = process.env.BINARY_SUPPORT === "yes";
@@ -11,7 +12,8 @@ const reqResMapper = (event, callback) => {
   };
   let responsePromise;
 
-  const req = new Stream.Readable();
+  const newStream = new Stream.Readable();
+  const req = Object.assign(newStream, http.IncomingMessage.prototype);
   req.url =
     (event.requestContext.path || event.path || "").replace(
       new RegExp("^/" + event.requestContext.stage),

--- a/packages/lambda-at-edge-compat/__tests__/next-aws-cloudfront.request.test.js
+++ b/packages/lambda-at-edge-compat/__tests__/next-aws-cloudfront.request.test.js
@@ -1,4 +1,5 @@
 const create = require("../next-aws-cloudfront");
+const http = require("http");
 
 const { SPECIAL_NODE_HEADERS } = create;
 
@@ -193,5 +194,34 @@ describe("Request Tests", () => {
 
     expect(req.connection).toEqual({});
     done();
+  });
+
+  it("request preserve http.IncomingMessage.prototype property", () => {
+    const exampleProperty = "I'm an example property";
+    http.IncomingMessage.prototype.exampleProperty = exampleProperty;
+    const { req } = create({
+      request: {
+        uri: ""
+      }
+    });
+
+    expect(typeof req.exampleProperty !== "undefined").toEqual(true);
+    expect(req.exampleProperty).toEqual(exampleProperty);
+  });
+
+  it("request preserve http.IncomingMessage.prototype function", () => {
+    const exampleFunction = function() {
+      return "I'm an example function.";
+    };
+    http.IncomingMessage.prototype.exampleFunction = exampleFunction;
+    const { req } = create({
+      request: {
+        uri: ""
+      }
+    });
+
+    expect(typeof req.exampleFunction === "function").toEqual(true);
+    expect(req.exampleFunction()).toEqual(exampleFunction());
+    expect(req.exampleFunction.toString()).toEqual(exampleFunction.toString());
   });
 });

--- a/packages/lambda-at-edge-compat/next-aws-cloudfront.js
+++ b/packages/lambda-at-edge-compat/next-aws-cloudfront.js
@@ -1,5 +1,6 @@
 const Stream = require("stream");
 const zlib = require("zlib");
+const http = require("http");
 
 const specialNodeHeaders = [
   "age",
@@ -89,7 +90,8 @@ const handler = event => {
     headers: {}
   };
 
-  const req = new Stream.Readable();
+  const newStream = new Stream.Readable();
+  const req = Object.assign(newStream, http.IncomingMessage.prototype);
   req.url = cfRequest.uri;
   req.method = cfRequest.method;
   req.rawHeaders = [];

--- a/packages/lambda-at-edge-compat/package-lock.json
+++ b/packages/lambda-at-edge-compat/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@types/aws-lambda": {
       "version": "8.10.50",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.50.tgz",
+      "resolved": false,
       "integrity": "sha512-RDzmQ5mO1f0BViKiuOudENZmoCACEa461nTRVtxhsAiEqGCgwdhCYN0aFgk42X5+ELAiqJKbv2mK0LkopYRYQg==",
       "dev": true
     }


### PR DESCRIPTION
Closes https://github.com/danielcondemarin/serverless-next.js/issues/384

For testing, I've added the below lines to my `serverless.yml` file just like explained in [CONTRIBUTING.md](https://github.com/danielcondemarin/serverless-next.js/blob/47fb657f49ba68cd79a8b8b4328c797bda9e7d24/CONTRIBUTING.md#testing-the-plugin-on-a-serverless-application):
```yaml
plugins:
  localPath: "/home/mertyildiran/Downloads/serverless-next.js/packages/serverless-plugin"
  modules:
    - index
```
and deployed to AWS CloudFront but I think it didn't use my fork. I also tried to directly edit from `node_modules` but I think it didn't take any effect too. Probably I'm doing something wrong in the local development process.

I'm opening this PR because the tests I've added show that it works. @danielcondemarin if you guide me for testing my fork on AWS CloudFront then I can provide you further info or fix if anything is wrong.