### PR TITLE
Custom cloudfront bug fixes

### DIFF
--- a/packages/serverless-component/__tests__/custom-inputs.test.js
+++ b/packages/serverless-component/__tests__/custom-inputs.test.js
@@ -520,10 +520,10 @@ describe("Custom inputs", () => {
         "PATCH"
       ],
       "lambda@edge": {
-        "origin-request":
-          "arn:aws:lambda:us-east-1:123456789012:function:my-func:v1",
         ...(expectedInConfig["api/*"] &&
-          expectedInConfig["api/*"]["lambda@edge"])
+          expectedInConfig["api/*"]["lambda@edge"]),
+        "origin-request":
+          "arn:aws:lambda:us-east-1:123456789012:function:my-func:v1"
       }
     };
 

--- a/packages/serverless-component/serverless.js
+++ b/packages/serverless-component/serverless.js
@@ -29,7 +29,7 @@ class NextjsComponent extends Component {
       throw Error("Duplicate path declared in cloudfront configuration");
     }
 
-    // there wont be a pages for these paths for this so we can remove them
+    // there wont be pages for these paths for this so we can remove them
     stillToMatch.delete("api/*");
     stillToMatch.delete("static/*");
     stillToMatch.delete("_next/*");


### PR DESCRIPTION
Hey, I just found a few bugs when I went to use the custom cloudfront configs.

1. custom configs for `static/*` may fail validation because there wont be any pages at these paths (the same for `_next/*`)
2. The nodejs AWS SDK will throw an error if you have an undefined value for a key, meaning we need to preprocess the values

correct me if im wrong, but we have tests for the second case, i think the mock API behaves differently