### PR TITLE
Explicitly set host header for s3 origin

### DIFF
--- a/packages/lambda-at-edge/src/default-handler.ts
+++ b/packages/lambda-at-edge/src/default-handler.ts
@@ -69,6 +69,7 @@ export const handler = async (
     s3Origin.path = isHTMLPage ? "/static-pages" : "/public";
 
     if (isHTMLPage) {
+      request.headers["host"] = [{ key: "host", value: s3Origin.domainName }];
       request.uri = uri + ".html";
     }
 

--- a/packages/lambda-at-edge/src/default-handler.ts
+++ b/packages/lambda-at-edge/src/default-handler.ts
@@ -15,6 +15,13 @@ import {
   OriginRequestDefaultHandlerManifest
 } from "./types";
 
+const addS3HostHeader = (
+  req: CloudFrontRequest,
+  s3DomainName: string
+): void => {
+  req.headers["host"] = [{ key: "host", value: s3DomainName }];
+};
+
 const router = (
   manifest: OriginRequestDefaultHandlerManifest
 ): ((path: string) => string) => {
@@ -69,7 +76,7 @@ export const handler = async (
     s3Origin.path = isHTMLPage ? "/static-pages" : "/public";
 
     if (isHTMLPage) {
-      request.headers["host"] = [{ key: "host", value: s3Origin.domainName }];
+      addS3HostHeader(request, s3Origin.domainName);
       request.uri = uri + ".html";
     }
 
@@ -81,6 +88,7 @@ export const handler = async (
   if (pagePath.endsWith(".html")) {
     s3Origin.path = "/static-pages";
     request.uri = pagePath.replace("pages", "");
+    addS3HostHeader(request, s3Origin.domainName);
     return request;
   }
 

--- a/packages/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -55,7 +55,7 @@ describe("Lambda@Edge", () => {
             }
           });
 
-          const request = await handler(event, {});
+          const request = await handler(event);
 
           expect(request.origin).toEqual({
             s3: {
@@ -65,6 +65,10 @@ describe("Lambda@Edge", () => {
             }
           });
           expect(request.uri).toEqual(expectedPage);
+          expect(request.headers.host[0].key).toEqual("host");
+          expect(request.headers.host[0].value).toEqual(
+            "my-bucket.s3.amazonaws.com"
+          );
         }
       );
     });


### PR DESCRIPTION
## Background
- I ran into some issues when I started forwarding the `Host` header from cloudfront. It causes signature invalidation on the request because the host is used to generate the signature
- https://github.com/danielcondemarin/serverless-next.js/issues/408

## Change
- Explicitly set the host header when forwarding requests to S3 origin

## Testing
- Tested on my own website. Confirmed the fix