### PR TITLE
Prevent client cache of static pages

### DIFF
--- a/packages/s3-static-assets/src/index.ts
+++ b/packages/s3-static-assets/src/index.ts
@@ -3,7 +3,10 @@ import path from "path";
 import fse from "fs-extra";
 import readDirectoryFiles from "./lib/readDirectoryFiles";
 import filterOutDirectories from "./lib/filterOutDirectories";
-import { IMMUTABLE_CACHE_CONTROL_HEADER } from "./lib/constants";
+import {
+  IMMUTABLE_CACHE_CONTROL_HEADER,
+  NO_STORE_CACHE_CONTROL_HEADER
+} from "./lib/constants";
 import S3ClientFactory, { Credentials } from "./lib/s3";
 import pathToPosix from "./lib/pathToPosix";
 import { PrerenderManifest } from "next/dist/build/index";
@@ -66,7 +69,8 @@ const uploadStaticAssets = async (
           /^pages\//,
           ""
         )}`,
-        filePath: pageFilePath
+        filePath: pageFilePath,
+        cacheControl: NO_STORE_CACHE_CONTROL_HEADER
       });
     });
 
@@ -105,7 +109,8 @@ const uploadStaticAssets = async (
 
     return s3.uploadFile({
       s3Key: path.posix.join("static-pages", relativePageFilePath),
-      filePath: pageFilePath
+      filePath: pageFilePath,
+      cacheControl: NO_STORE_CACHE_CONTROL_HEADER
     });
   });
 

--- a/packages/s3-static-assets/src/lib/constants.ts
+++ b/packages/s3-static-assets/src/lib/constants.ts
@@ -4,3 +4,5 @@ export const IMMUTABLE_CACHE_CONTROL_HEADER =
 export const DEFAULT_PUBLIC_DIR_CACHE_CONTROL =
   "public, max-age=31536000, must-revalidate";
 export const DEFAULT_PUBLIC_DIR_CACHE_REGEX = /\.(gif|jpe?g|jp2|tiff|png|webp|bmp|svg|ico)$/i;
+
+export const NO_STORE_CACHE_CONTROL_HEADER = "no-store";

--- a/packages/s3-static-assets/tests/upload-assets.test.ts
+++ b/packages/s3-static-assets/tests/upload-assets.test.ts
@@ -2,7 +2,8 @@ import path from "path";
 import uploadStaticAssets from "../src/index";
 import {
   IMMUTABLE_CACHE_CONTROL_HEADER,
-  DEFAULT_PUBLIC_DIR_CACHE_CONTROL
+  DEFAULT_PUBLIC_DIR_CACHE_CONTROL,
+  NO_STORE_CACHE_CONTROL_HEADER
 } from "../src/lib/constants";
 import AWS, {
   mockGetBucketAccelerateConfigurationPromise,
@@ -136,7 +137,7 @@ describe.each`
         expect.objectContaining({
           Key: "static-pages/todos/terms.html",
           ContentType: "text/html",
-          CacheControl: undefined
+          CacheControl: NO_STORE_CACHE_CONTROL_HEADER
         })
       );
 
@@ -144,7 +145,7 @@ describe.each`
         expect.objectContaining({
           Key: "static-pages/todos/terms/[section].html",
           ContentType: "text/html",
-          CacheControl: undefined
+          CacheControl: NO_STORE_CACHE_CONTROL_HEADER
         })
       );
     });
@@ -184,7 +185,7 @@ describe.each`
         expect.objectContaining({
           Key: "static-pages/todos/terms/a.html",
           ContentType: "text/html",
-          CacheControl: undefined
+          CacheControl: NO_STORE_CACHE_CONTROL_HEADER
         })
       );
 
@@ -192,7 +193,7 @@ describe.each`
         expect.objectContaining({
           Key: "static-pages/todos/terms/b.html",
           ContentType: "text/html",
-          CacheControl: undefined
+          CacheControl: NO_STORE_CACHE_CONTROL_HEADER
         })
       );
     });


### PR DESCRIPTION
### Problem
The serverless component is not preventing clients (e.g. browsers) from caching static pages locally. We have to prevent this behaviour, since static pages have references to chunks and other static files that are generated per app build. If a static page gets cached locally and a new version is deployed, clients that have a static page cached will be referencing assets from a previous version/build and this may lead to unexpected errors. Vercel Edge Network, for example, returns by default a `Cache-Control` header containing `public, max-age=0, must-revalidate` for static files (see [docs](https://vercel.com/docs/v2/edge-network/caching#static-files)).

### Solution
With this PR, `serverless-next.js` will add a `Cache-Control: no-store` header to static page objects uploaded to S3, preventing them from being cached locally by clients.

Related issues: #420 