### PR TITLE
fix support for next/dynamic import

### DIFF
--- a/packages/lambda-at-edge/src/build.ts
+++ b/packages/lambda-at-edge/src/build.ts
@@ -14,6 +14,8 @@ import pathToPosix from "./lib/pathToPosix";
 import expressifyDynamicRoute from "./lib/expressifyDynamicRoute";
 import pathToRegexStr from "./lib/pathToRegexStr";
 import createServerlessConfig from "./lib/createServerlessConfig";
+import isChunk from "./lib/isChunk";
+import pathToFilename from "./lib/pathToFilename";
 
 export const DEFAULT_LAMBDA_CODE_DIR = "default-lambda";
 export const API_LAMBDA_CODE_DIR = "api-lambda";
@@ -123,9 +125,14 @@ class Builder {
         const resolvedFilePath = path.resolve(filePath);
         const dst = path.relative(this.nextConfigDir, resolvedFilePath);
 
+        // chunks are geting copied to root. others remain same
         return fse.copy(
           resolvedFilePath,
-          join(this.outputDir, handlerDirectory, dst)
+          join(
+            this.outputDir,
+            handlerDirectory,
+            isChunk(filePath) ? pathToFilename(dst) : dst
+          )
         );
       });
   }

--- a/packages/lambda-at-edge/src/default-handler.ts
+++ b/packages/lambda-at-edge/src/default-handler.ts
@@ -72,6 +72,11 @@ export const handler = async (
 
   const isHTMLPage = isStaticPage || isPrerenderedPage;
 
+  if (uri === "/service-worker.js") {
+    s3Origin.path = "/_next/static";
+    return request;
+  }
+
   if (isHTMLPage || isPublicFile) {
     s3Origin.path = isHTMLPage ? "/static-pages" : "/public";
 

--- a/packages/lambda-at-edge/src/lib/isChunk.ts
+++ b/packages/lambda-at-edge/src/lib/isChunk.ts
@@ -1,0 +1,6 @@
+const isChunk = (path: string): boolean => {
+  // Identify .next/serverless/[number].[alpha_numeric].js pattern
+  return /^(.next\/serverless\/)[\d]+\.+[\w,\s-]+\.(js)$/.test(path);
+};
+
+export default isChunk;

--- a/packages/lambda-at-edge/src/lib/pathToFilename.ts
+++ b/packages/lambda-at-edge/src/lib/pathToFilename.ts
@@ -1,0 +1,2 @@
+const pathToFilename = (path: string): string => path.replace(/^.*[\\\/]/, "");
+export default pathToFilename;


### PR DESCRIPTION
#236 
Just added one condition into `copyLambdaHandlerDependencies` method to coping chunks into the valid directory. [Ref](https://github.com/danielcondemarin/serverless-next.js/issues/236#issuecomment-637912442) 

#357 
also added service-worker support.