### PR TITLE
Cache static pages and invalidate distribution after deploy

### DIFF
--- a/packages/cloudfront/CHANGELOG.md
+++ b/packages/cloudfront/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/cloudfront/README.md
+++ b/packages/cloudfront/README.md
@@ -1,0 +1,1 @@
+### AWS CloudFront helper library

--- a/packages/cloudfront/package-lock.json
+++ b/packages/cloudfront/package-lock.json
@@ -1,0 +1,108 @@
+{
+  "name": "@sls-next/cloudfront",
+  "version": "1.0.0-alpha.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.691.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.691.0.tgz",
+      "integrity": "sha512-HV/iANH5PJvexubWr/oDmWMKtV/n1shtrACrLIUa5vTXIT6O7CzUouExNOvOtFMZw8zJkLmyEpa/0bDpMmo0Zg==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "typescript": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+      "dev": true
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@sls-next/cloudfront",
+  "version": "1.0.0-alpha.0",
+  "description": "Handles CloudFront invalidation",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "directories": {
+    "dist": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danielcondemarin/serverless-next.js.git",
+    "directory": "packages/cloudfront"
+  },
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "keywords": [
+    "AWS",
+    "CloudFront",
+    "Next.js",
+    "Serverless"
+  ],
+  "author": "Daniel Conde Marin <danielconde9@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/danielcondemarin/serverless-next.js/issues"
+  },
+  "homepage": "https://github.com/danielcondemarin/serverless-next.js#readme",
+  "dependencies": {
+    "aws-sdk": "^2.664.0"
+  },
+  "devDependencies": {
+    "typescript": "^3.8.3"
+  }
+}

--- a/packages/cloudfront/src/index.ts
+++ b/packages/cloudfront/src/index.ts
@@ -1,0 +1,21 @@
+import AWS from "aws-sdk";
+import CloudFrontClientFactory, { Credentials } from "./lib/cloudfront";
+
+export type CreateInvalidationOptions = {
+  credentials: Credentials;
+  distributionId: string;
+  paths?: string[];
+};
+
+const createInvalidation = async (
+  options: CreateInvalidationOptions
+): Promise<AWS.CloudFront.CreateInvalidationResult> => {
+  const { credentials, distributionId, paths } = options;
+  const cf = CloudFrontClientFactory({
+    credentials
+  });
+
+  return cf.createInvalidation({ distributionId, paths });
+};
+
+export default createInvalidation;

--- a/packages/cloudfront/src/lib/cloudfront.ts
+++ b/packages/cloudfront/src/lib/cloudfront.ts
@@ -1,0 +1,56 @@
+import AWS from "aws-sdk";
+import { ALL_FILES_PATH } from "./constants";
+
+type CloudFrontClientFactoryOptions = {
+  credentials: Credentials;
+};
+
+type CreateInvalidationOptions = {
+  distributionId: string;
+  callerReference?: string;
+  paths?: string[];
+};
+
+export type CloudFrontClient = {
+  createInvalidation: (
+    options: CreateInvalidationOptions
+  ) => Promise<AWS.CloudFront.CreateInvalidationResult>;
+};
+
+export type Credentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+};
+
+export default ({
+  credentials
+}: CloudFrontClientFactoryOptions): CloudFrontClient => {
+  const cloudFront = new AWS.CloudFront({ credentials });
+
+  return {
+    createInvalidation: async (
+      options: CreateInvalidationOptions
+    ): Promise<AWS.CloudFront.CreateInvalidationResult> => {
+      const timestamp = +new Date() + "";
+      const {
+        distributionId,
+        callerReference = timestamp,
+        paths = [ALL_FILES_PATH]
+      } = options;
+
+      return await cloudFront
+        .createInvalidation({
+          DistributionId: distributionId,
+          InvalidationBatch: {
+            CallerReference: callerReference,
+            Paths: {
+              Quantity: paths.length,
+              Items: paths
+            }
+          }
+        })
+        .promise();
+    }
+  };
+};

--- a/packages/cloudfront/src/lib/constants.ts
+++ b/packages/cloudfront/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const ALL_FILES_PATH = "/*";

--- a/packages/cloudfront/tests/aws-sdk.mock.ts
+++ b/packages/cloudfront/tests/aws-sdk.mock.ts
@@ -1,0 +1,23 @@
+declare module "aws-sdk" {
+  const mockCreateInvalidation: jest.Mock;
+  const mockCreateInvalidationPromise: jest.Mock;
+}
+
+const promisifyMock = (mockFn: jest.Mock): jest.Mock => {
+  const promise = jest.fn();
+  mockFn.mockReturnValue({ promise });
+  return promise;
+};
+
+export const mockCreateInvalidation = jest.fn();
+export const mockCreateInvalidationPromise = promisifyMock(
+  mockCreateInvalidation
+);
+
+const MockCloudFront = jest.fn(() => ({
+  createInvalidation: mockCreateInvalidation
+}));
+
+export default {
+  CloudFront: MockCloudFront
+};

--- a/packages/cloudfront/tests/cache-invalidation.test.ts
+++ b/packages/cloudfront/tests/cache-invalidation.test.ts
@@ -1,0 +1,64 @@
+import AWS, { mockCreateInvalidation } from "aws-sdk";
+import createInvalidation, { CreateInvalidationOptions } from "../src/index";
+import { ALL_FILES_PATH } from "../src/lib/constants";
+
+jest.mock("aws-sdk", () => require("./aws-sdk.mock"));
+
+const invalidate = (
+  options: Partial<CreateInvalidationOptions> = {}
+): Promise<AWS.CloudFront.CreateInvalidationResult> => {
+  return createInvalidation({
+    ...options,
+    distributionId: "fake-distribution-id",
+    credentials: {
+      accessKeyId: "fake-access-key",
+      secretAccessKey: "fake-secret-key",
+      sessionToken: "fake-session-token"
+    }
+  });
+};
+
+describe("Cache invalidation tests", () => {
+  it("passes credentials to CloudFront client", async () => {
+    await invalidate();
+
+    expect(AWS.CloudFront).toBeCalledWith({
+      credentials: {
+        accessKeyId: "fake-access-key",
+        secretAccessKey: "fake-secret-key",
+        sessionToken: "fake-session-token"
+      }
+    });
+  });
+
+  it("invalidates CloudFront distribution", async () => {
+    await invalidate();
+
+    expect(mockCreateInvalidation).toBeCalledWith({
+      DistributionId: "fake-distribution-id",
+      InvalidationBatch: {
+        CallerReference: expect.stringMatching(/^\d+$/),
+        Paths: {
+          Quantity: 1,
+          Items: [ALL_FILES_PATH]
+        }
+      }
+    });
+  });
+
+  it("invalidates specified paths", async () => {
+    const paths = ["/static/page1", "/static/page2"];
+    await invalidate({ paths });
+
+    expect(mockCreateInvalidation).toBeCalledWith({
+      DistributionId: "fake-distribution-id",
+      InvalidationBatch: {
+        CallerReference: expect.stringMatching(/^\d+$/),
+        Paths: {
+          Quantity: 2,
+          Items: paths
+        }
+      }
+    });
+  });
+});

--- a/packages/cloudfront/tsconfig.build.json
+++ b/packages/cloudfront/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "removeComments": true
+  },
+  "include": ["./src/"]
+}

--- a/packages/cloudfront/tsconfig.json
+++ b/packages/cloudfront/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "target": "ES2015",
+    "module": "CommonJS",
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "strict": true,
+    "allowJs": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["**/*.ts"]
+}

--- a/packages/s3-static-assets/src/index.ts
+++ b/packages/s3-static-assets/src/index.ts
@@ -5,7 +5,7 @@ import readDirectoryFiles from "./lib/readDirectoryFiles";
 import filterOutDirectories from "./lib/filterOutDirectories";
 import {
   IMMUTABLE_CACHE_CONTROL_HEADER,
-  NO_STORE_CACHE_CONTROL_HEADER
+  SERVER_CACHE_CONTROL_HEADER
 } from "./lib/constants";
 import S3ClientFactory, { Credentials } from "./lib/s3";
 import pathToPosix from "./lib/pathToPosix";
@@ -70,7 +70,7 @@ const uploadStaticAssets = async (
           ""
         )}`,
         filePath: pageFilePath,
-        cacheControl: NO_STORE_CACHE_CONTROL_HEADER
+        cacheControl: SERVER_CACHE_CONTROL_HEADER
       });
     });
 
@@ -110,7 +110,7 @@ const uploadStaticAssets = async (
     return s3.uploadFile({
       s3Key: path.posix.join("static-pages", relativePageFilePath),
       filePath: pageFilePath,
-      cacheControl: NO_STORE_CACHE_CONTROL_HEADER
+      cacheControl: SERVER_CACHE_CONTROL_HEADER
     });
   });
 

--- a/packages/s3-static-assets/src/lib/constants.ts
+++ b/packages/s3-static-assets/src/lib/constants.ts
@@ -1,8 +1,9 @@
 export const IMMUTABLE_CACHE_CONTROL_HEADER =
   "public, max-age=31536000, immutable";
 
+export const SERVER_CACHE_CONTROL_HEADER =
+  "public, max-age=0, s-maxage=86400, must-revalidate";
+
 export const DEFAULT_PUBLIC_DIR_CACHE_CONTROL =
   "public, max-age=31536000, must-revalidate";
 export const DEFAULT_PUBLIC_DIR_CACHE_REGEX = /\.(gif|jpe?g|jp2|tiff|png|webp|bmp|svg|ico)$/i;
-
-export const NO_STORE_CACHE_CONTROL_HEADER = "no-store";

--- a/packages/s3-static-assets/src/lib/constants.ts
+++ b/packages/s3-static-assets/src/lib/constants.ts
@@ -2,8 +2,9 @@ export const IMMUTABLE_CACHE_CONTROL_HEADER =
   "public, max-age=31536000, immutable";
 
 export const SERVER_CACHE_CONTROL_HEADER =
-  "public, max-age=0, s-maxage=86400, must-revalidate";
+  "public, max-age=0, s-maxage=2678400, must-revalidate";
 
 export const DEFAULT_PUBLIC_DIR_CACHE_CONTROL =
   "public, max-age=31536000, must-revalidate";
+
 export const DEFAULT_PUBLIC_DIR_CACHE_REGEX = /\.(gif|jpe?g|jp2|tiff|png|webp|bmp|svg|ico)$/i;

--- a/packages/s3-static-assets/tests/upload-assets.test.ts
+++ b/packages/s3-static-assets/tests/upload-assets.test.ts
@@ -3,7 +3,7 @@ import uploadStaticAssets from "../src/index";
 import {
   IMMUTABLE_CACHE_CONTROL_HEADER,
   DEFAULT_PUBLIC_DIR_CACHE_CONTROL,
-  NO_STORE_CACHE_CONTROL_HEADER
+  SERVER_CACHE_CONTROL_HEADER
 } from "../src/lib/constants";
 import AWS, {
   mockGetBucketAccelerateConfigurationPromise,
@@ -137,7 +137,7 @@ describe.each`
         expect.objectContaining({
           Key: "static-pages/todos/terms.html",
           ContentType: "text/html",
-          CacheControl: NO_STORE_CACHE_CONTROL_HEADER
+          CacheControl: SERVER_CACHE_CONTROL_HEADER
         })
       );
 
@@ -145,7 +145,7 @@ describe.each`
         expect.objectContaining({
           Key: "static-pages/todos/terms/[section].html",
           ContentType: "text/html",
-          CacheControl: NO_STORE_CACHE_CONTROL_HEADER
+          CacheControl: SERVER_CACHE_CONTROL_HEADER
         })
       );
     });
@@ -185,7 +185,7 @@ describe.each`
         expect.objectContaining({
           Key: "static-pages/todos/terms/a.html",
           ContentType: "text/html",
-          CacheControl: NO_STORE_CACHE_CONTROL_HEADER
+          CacheControl: SERVER_CACHE_CONTROL_HEADER
         })
       );
 
@@ -193,7 +193,7 @@ describe.each`
         expect.objectContaining({
           Key: "static-pages/todos/terms/b.html",
           ContentType: "text/html",
-          CacheControl: NO_STORE_CACHE_CONTROL_HEADER
+          CacheControl: SERVER_CACHE_CONTROL_HEADER
         })
       );
     });

--- a/packages/serverless-component/__mocks__/@sls-next/cloudfront.js
+++ b/packages/serverless-component/__mocks__/@sls-next/cloudfront.js
@@ -1,0 +1,3 @@
+module.exports = {
+  default: jest.fn()
+};

--- a/packages/serverless-component/__tests__/deploy.test.js
+++ b/packages/serverless-component/__tests__/deploy.test.js
@@ -4,6 +4,7 @@ const NextjsComponent = require("../serverless");
 const { mockS3 } = require("@serverless/aws-s3");
 const { mockCloudFront } = require("@serverless/aws-cloudfront");
 const { mockLambda, mockLambdaPublish } = require("@serverless/aws-lambda");
+const mockCreateInvalidation = require("@sls-next/cloudfront");
 const {
   DEFAULT_LAMBDA_CODE_DIR,
   API_LAMBDA_CODE_DIR
@@ -45,6 +46,7 @@ describe("deploy tests", () => {
       version: "v1"
     });
     mockCloudFront.mockResolvedValueOnce({
+      id: "cloudfrontdistrib",
       url: "https://cloudfrontdistrib.amazonaws.com"
     });
 
@@ -160,6 +162,16 @@ describe("deploy tests", () => {
             }
           }
         ]
+      });
+    });
+
+    it("invalidates distribution cache", () => {
+      expect(mockCreateInvalidation.default).toBeCalledWith({
+        credentials: {
+          accessKeyId: "123",
+          secretAccessKey: "456"
+        },
+        distributionId: "cloudfrontdistrib"
       });
     });
   });

--- a/packages/serverless-component/package-lock.json
+++ b/packages/serverless-component/package-lock.json
@@ -187,6 +187,113 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
+    "@sls-next/cloudfront": {
+      "version": "file:../cloudfront",
+      "requires": {
+        "aws-sdk": "^2.664.0"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "version": "2.691.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.691.0.tgz",
+          "integrity": "sha512-HV/iANH5PJvexubWr/oDmWMKtV/n1shtrACrLIUa5vTXIT6O7CzUouExNOvOtFMZw8zJkLmyEpa/0bDpMmo0Zg==",
+          "requires": {
+            "buffer": "4.9.2",
+            "events": "1.1.1",
+            "ieee754": "1.1.13",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.3.2",
+            "xml2js": "0.4.19"
+          }
+        },
+        "base64-js": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+          "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+        },
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "jmespath": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+          "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "typescript": {
+          "version": "3.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+          "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ=="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+      }
+    },
     "@sls-next/lambda-at-edge": {
       "version": "file:../lambda-at-edge",
       "requires": {

--- a/packages/serverless-component/package.json
+++ b/packages/serverless-component/package.json
@@ -28,6 +28,7 @@
     "@serverless/aws-s3": "^4.2.0",
     "@serverless/core": "^1.0.0",
     "@serverless/domain": "^6.1.0",
+    "@sls-next/cloudfront": "file:../cloudfront",
     "@sls-next/lambda-at-edge": "file:../lambda-at-edge",
     "@sls-next/s3-static-assets": "file:../s3-static-assets",
     "fs-extra": "^8.1.0",

--- a/packages/serverless-component/serverless.js
+++ b/packages/serverless-component/serverless.js
@@ -3,6 +3,7 @@ const fse = require("fs-extra");
 const path = require("path");
 const { Builder } = require("@sls-next/lambda-at-edge");
 const uploadAssetsToS3 = require("@sls-next/s3-static-assets");
+const createInvalidation = require("@sls-next/cloudfront");
 
 const obtainDomains = require("./lib/obtainDomains");
 const { DEFAULT_LAMBDA_CODE_DIR, API_LAMBDA_CODE_DIR } = require("./constants");
@@ -421,6 +422,12 @@ class NextjsComponent extends Component {
     });
 
     let appUrl = cloudFrontOutputs.url;
+
+    // create invalidation
+    await createInvalidation.default({
+      distributionId: cloudFrontOutputs.id,
+      credentials: this.context.credentials.aws
+    });
 
     // create domain
     const { domain, subdomain } = obtainDomains(inputs.domain);


### PR DESCRIPTION
### Problem
As reported by #430, static pages are not cached by CloudFront and client requests are always hitting the origin.

### Expected behaviour
Static pages should be automatically cached at the edge after the first request for an arbitrary long period of time. When a new deployment occurs, the CloudFront cache should be invalidated, ensuring that the latest version is served to clients. This gives us the most flexibility, as users get the latest file from CDN immediately after deploying.

### Solution
- Instead of using `Cache-Control: no-store` for static pages, the component now uses `public, max-age=0, s-maxage=86400, must-revalidate`. This prevents the page from being cached in the browser, but `s-maxage` allows the page to be cached at edge locations for 1 day (86400 seconds). 
- An invalidation request for all paths (`/*`) is created after each deployment, thus ensuring that the latest version is always served to clients while using the CDN effectively.

### Implementation details
- A helper package, called `@sls-next/cloudfront`, was created to handle cache invalidation. We could also expose an invalidation method on `@serverless/aws-cloudfront` component, similar to `@serverless/aws-s3` [upload](https://github.com/serverless-components/aws-s3/blob/master/serverless.js#L109) helper method to upload files, but Components `v1` is no longer maintained and we would need to get it merged.
- Timestamp was used as [`CallerReference`](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_InvalidationBatch.html) for the cache invalidation request. We could also use the Next.js BUILD_ID.
- An arbitrary cache period of 1 day was used. We could increase this for a longer time ([Vercel uses 31 days](https://vercel.com/docs/v2/edge-network/caching#static-files)).

resolves #430 