### PR TITLE
use a fork of aws-lambda to be able to rename lambdas

### DIFF
--- a/packages/serverless-component/package-lock.json
+++ b/packages/serverless-component/package-lock.json
@@ -39,9 +39,8 @@
       }
     },
     "@serverless/aws-lambda": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@serverless/aws-lambda/-/aws-lambda-3.0.3.tgz",
-      "integrity": "sha512-iLA16GJcfVL5uogqO9HcEAg0fs9y94tiO390c5PSRHUPuu6pNHPFSAJPAKDpamodEtRWR1JRooKyw20W0XM4Xg==",
+      "version": "git+https://github.com/lone-cloud/aws-lambda.git#2d33ff9e23b9d0fbff460875d8a3120f6ea13ca4",
+      "from": "git+https://github.com/lone-cloud/aws-lambda.git#2d33ff9e23b9d0fbff460875d8a3120f6ea13ca4",
       "requires": {
         "@serverless/aws-iam-role": "^1.0.0",
         "@serverless/aws-lambda-layer": "^1.0.0",
@@ -1460,17 +1459,11 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-    },
     "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
       "requires": {
-        "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
       }
@@ -1481,9 +1474,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "13.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
-      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
     },
     "archiver": {
       "version": "3.1.1",
@@ -2572,9 +2565,9 @@
       }
     },
     "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "micromatch": {
       "version": "3.1.10",

--- a/packages/serverless-component/package.json
+++ b/packages/serverless-component/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@serverless/aws-cloudfront": "^5.0.0",
-    "@serverless/aws-lambda": "^3.0.3",
+    "@serverless/aws-lambda": "https://github.com/lone-cloud/aws-lambda#2d33ff9e23b9d0fbff460875d8a3120f6ea13ca4",
     "@serverless/aws-s3": "^4.2.0",
     "@serverless/core": "^1.0.0",
     "@serverless/domain": "^6.1.0",


### PR DESCRIPTION
fixes #308 

I propose this change because the major version for aws-lambda that this lib uses is no longer maintained and until this lib is able to integrate with aws-lambda v2, it would be nice to be able update the lambda names.

The core fix here is: https://github.com/lone-cloud/aws-lambda/commit/2d33ff9e23b9d0fbff460875d8a3120f6ea13ca4