### PR TITLE
feat: normalise trailing slashes

### DIFF
--- a/packages/lambda-at-edge/src/default-handler.ts
+++ b/packages/lambda-at-edge/src/default-handler.ts
@@ -66,7 +66,15 @@ const router = (
   };
 };
 
-const normaliseUri = (uri: string): string => (uri === "/" ? "/index" : uri);
+const normaliseUri = (uri: string): string => {
+  if (uri === "/") {
+    return "/index";
+  }
+  if (uri.endsWith("/")) {
+    return uri.slice(0, -1);
+  }
+  return uri;
+};
 
 export const handler = async (
   event: OriginRequestEvent

--- a/packages/lambda-at-edge/tests/default-handler/default-handler.test.ts
+++ b/packages/lambda-at-edge/tests/default-handler/default-handler.test.ts
@@ -36,6 +36,7 @@ describe("Lambda@Edge", () => {
         ${"/"}                                             | ${"/index.html"}
         ${"/index"}                                        | ${"/index.html"}
         ${"/terms"}                                        | ${"/terms.html"}
+        ${"/terms/"}                                       | ${"/terms.html"}
         ${"/users/batman"}                                 | ${"/users/[user].html"}
         ${"/users/test/catch/all"}                         | ${"/users/[...user].html"}
         ${"/john/123"}                                     | ${"/[username]/[id].html"}
@@ -106,6 +107,7 @@ describe("Lambda@Edge", () => {
         path                              | expectedPage
         ${"/abc"}                         | ${"pages/[root].js"}
         ${"/blog/foo"}                    | ${"pages/blog/[id].js"}
+        ${"/blog/foo/"}                   | ${"pages/blog/[id].js"}
         ${"/customers"}                   | ${"pages/customers/index.js"}
         ${"/customers/superman"}          | ${"pages/customers/[customer].js"}
         ${"/customers/superman/howtofly"} | ${"pages/customers/[customer]/[post].js"}


### PR DESCRIPTION
Since #249 was closed. This is a much needed feature. Next.js is working on this here: vercel/next.js#13333 but it seems to be taking long. It would be really nice if we can support this in the component.

### Details

If a page exists on `example.com/about` then visiting `example.com/about/` returns 404 Not found error. This PR normalises paths with trailing slashes such that `example.com/about/` resolves to `example.com/about`.