### PR TITLE
document the full list of AWS permissions required for a deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ The exhaustive list of AWS actions required for a deployment:
   "route53:ListResourceRecordSets",   // only for custom domains
   "s3:CreateBucket",
   "s3:GetAccelerateConfiguration",
+  "s3:GetObject",                     // only if persisting state to S3 for CI/CD
   "s3:HeadBucket",
   "s3:ListBucket",
   "s3:PutAccelerateConfiguration",

--- a/README.md
+++ b/README.md
@@ -217,6 +217,51 @@ myNextApplication:
 
 Make sure you add CloudWatch log permissions to your custom policy.
 
+The exhaustive list of AWS actions required for a deployment:
+
+```
+  "acm:DescribeCertificate", // only for custom domains
+  "acm:ListCertificates",    // only for custom domains
+  "acm:RequestCertificate",  // only for custom domains
+  "cloudfront:CreateCloudFrontOriginAccessIdentity",
+  "cloudfront:CreateDistribution",
+  "cloudfront:CreateInvalidation",
+  "cloudfront:GetDistribution",
+  "cloudfront:GetDistributionConfig",
+  "cloudfront:ListCloudFrontOriginAccessIdentities",
+  "cloudfront:ListDistributions",
+  "cloudfront:ListDistributionsByLambdaFunction",
+  "cloudfront:ListDistributionsByWebACLId",
+  "cloudfront:ListFieldLevelEncryptionConfigs",
+  "cloudfront:ListFieldLevelEncryptionProfiles",
+  "cloudfront:ListInvalidations",
+  "cloudfront:ListPublicKeys",
+  "cloudfront:ListStreamingDistributions",
+  "cloudfront:UpdateDistribution",
+  "iam:AttachRolePolicy",
+  "iam:CreateRole",
+  "iam:CreateServiceLinkedRole",
+  "iam:GetRole",
+  "iam:PassRole",
+  "lambda:CreateFunction",
+  "lambda:EnableReplication",
+  "lambda:GetFunction",
+  "lambda:GetFunctionConfiguration",
+  "lambda:PublishVersion",
+  "lambda:UpdateFunctionCode",
+  "lambda:UpdateFunctionConfiguration",
+  "route53:ChangeResourceRecordSets", // only for custom domains
+  "route53:ListHostedZonesByName",
+  "route53:ListResourceRecordSets",   // only for custom domains
+  "s3:CreateBucket",
+  "s3:GetAccelerateConfiguration",
+  "s3:HeadBucket",
+  "s3:ListBucket",
+  "s3:PutAccelerateConfiguration",
+  "s3:PutBucketPolicy",
+  "s3:PutObject"
+```
+
 ### Lambda At Edge Configuration
 
 Both **default** and **api** edge lambdas will be assigned 512mb of memory by default. This value can be altered by assigning a number to the `memory` input


### PR DESCRIPTION
fixes #280 

I think it's invaluable to keep this info in the README. At least where I work, full admin access to AWS isn't given out to everybody and I had to come up with a more granular list listed here.