### PR TITLE
don't forward cookies, headers and query parameters for requests to static paths

### DIFF
--- a/packages/serverless-component/__tests__/custom-inputs.test.js
+++ b/packages/serverless-component/__tests__/custom-inputs.test.js
@@ -651,7 +651,12 @@ describe("Custom inputs", () => {
             ...customPageCacheBehaviours,
             "_next/static/*": {
               ...customPageCacheBehaviours["_next/static/*"],
-              ttl: 86400
+              ttl: 86400,
+              forward: {
+                headers: "none",
+                cookies: "none",
+                queryString: false
+              }
             },
             "_next/data/*": {
               ttl: 0,
@@ -667,7 +672,12 @@ describe("Custom inputs", () => {
             },
             "static/*": {
               ...customPageCacheBehaviours["static/*"],
-              ttl: 86400
+              ttl: 86400,
+              forward: {
+                headers: "none",
+                cookies: "none",
+                queryString: false
+              }
             }
           },
           private: true,

--- a/packages/serverless-component/__tests__/deploy.test.js
+++ b/packages/serverless-component/__tests__/deploy.test.js
@@ -139,7 +139,12 @@ describe("deploy tests", () => {
             private: true,
             pathPatterns: {
               "_next/static/*": {
-                ttl: 86400
+                ttl: 86400,
+                forward: {
+                  headers: "none",
+                  cookies: "none",
+                  queryString: false
+                }
               },
               "_next/data/*": {
                 ttl: 0,
@@ -150,7 +155,12 @@ describe("deploy tests", () => {
                 }
               },
               "static/*": {
-                ttl: 86400
+                ttl: 86400,
+                forward: {
+                  headers: "none",
+                  cookies: "none",
+                  queryString: false
+                }
               },
               "api/*": {
                 ttl: 0,

--- a/packages/serverless-component/serverless.js
+++ b/packages/serverless-component/serverless.js
@@ -230,10 +230,20 @@ class NextjsComponent extends Component {
         private: true,
         pathPatterns: {
           "_next/static/*": {
-            ttl: 86400
+            ttl: 86400,
+            forward: {
+              headers: "none",
+              cookies: "none",
+              queryString: false
+            }
           },
           "static/*": {
-            ttl: 86400
+            ttl: 86400,
+            forward: {
+              headers: "none",
+              cookies: "none",
+              queryString: false
+            }
           }
         }
       },


### PR DESCRIPTION
fixes #459 